### PR TITLE
Reduced Computational time.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.19.2
-matplotlib==3.3.2
-scipy==1.5.2
+numpy==2.3.0
+matplotlib==3.10.0
+scipy==1.16.0

--- a/src/PostProc.py
+++ b/src/PostProc.py
@@ -56,7 +56,7 @@ class PostProc:
         plt.legend()
         plt.xlabel('acceleration [m/s^2]')
         plt.ylabel('velocity [m/s]')
-        plt.grid(b=True, which='major', linestyle=':')
+        plt.grid(visible=True, which='major', linestyle=':')
         plt.ylim(0, self.vcarmax*1.2)
 
     def plotGGV(self, bPlotGGVfull=0):
@@ -121,22 +121,22 @@ class PostProc:
         ax1.plot(self.Fxgrip, self.vxvect, 'r-', label="FxGrip")
         ax1.plot(self.Fxdrive, self.vxvect, 'g-', label="FxDrive")
         ax1.legend()
-        ax1.grid(b=True, which='major', linestyle=':')
+        ax1.grid(visible=True, which='major', linestyle=':')
 
         ax2.set_title("Gear (vcar[m/s])")
         ax2.plot(self.nGear, self.vxvect, 'c-', label="nGear")
         ax2.legend()
-        ax2.grid(b=True, which='major', linestyle=':')
+        ax2.grid(visible=True, which='major', linestyle=':')
 
         ax3.set_title("EngNm (vcar[m/s])")
         ax3.plot(self.EngNm, self.vxvect, 'c-', label="EngNm")
         ax3.legend()
-        ax3.grid(b=True, which='major', linestyle=':')
+        ax3.grid(visible=True, which='major', linestyle=':')
 
         ax4.set_title("EngRpm (vcar[m/s])")
         ax4.plot(self.EngRpm, self.vxvect, 'c-', label="EngRpm")
         ax4.legend()
-        ax4.grid(b=True, which='major', linestyle=':')
+        ax4.grid(visible=True, which='major', linestyle=':')
 
     def plotLapTimeSim(self):
         plt.figure(2, figsize=(self.size, self.size/2))
@@ -145,7 +145,7 @@ class PostProc:
         plt.xlabel('distance [m]')
         plt.ylabel('velocity [m/s]')
         plt.legend()
-        plt.grid(b=True, which='major', linestyle=':')
+        plt.grid(visible=True, which='major', linestyle=':')
         plt.ylim(0, self.vcarmax*1.2)
         plt.xlim(0, max(self.dist))
 
@@ -159,7 +159,7 @@ class PostProc:
         plt.xlabel('distance [m]')
         plt.ylabel('velocity [m/s]')
         plt.legend()
-        plt.grid(b=True, which='major', linestyle=':')
+        plt.grid(visible=True, which='major', linestyle=':')
         plt.ylim(0, self.vcarmax*1.2)
         plt.xlim(0, max(self.dist))
 

--- a/src/RunOpenLapSim.py
+++ b/src/RunOpenLapSim.py
@@ -86,14 +86,9 @@ class RunOpenLapSim:
         trackFile = (self.trackFilesPath+self.trackFileName)
         l1 = LapTimeSimCalc(trackFile, aE.accEnvDict, None)
         l1.Run()
-        tend = time.time()
-        print(tend - tstart)
         l2 = LapTimeSimCalc(trackFile, aE.accEnvDict,
                             l1)
         l2.Run()
-        tend = time.time()
-        print(tend - tstart)
-
         # set output channels from simulation for Export
         vcar = l2.lapTimeSimDict["vcar"]  # car speed [m/s]
         dist = l2.lapTimeSimDict["dist"]  # circuit dist [m]

--- a/src/RunOpenLapSim.py
+++ b/src/RunOpenLapSim.py
@@ -84,11 +84,15 @@ class RunOpenLapSim:
 
         # Run Lap time Simulation
         trackFile = (self.trackFilesPath+self.trackFileName)
-        l1 = LapTimeSimCalc(trackFile, aE.accEnvDict, 10)
+        l1 = LapTimeSimCalc(trackFile, aE.accEnvDict, None)
         l1.Run()
+        tend = time.time()
+        print(tend - tstart)
         l2 = LapTimeSimCalc(trackFile, aE.accEnvDict,
-                            l1.lapTimeSimDict["vxaccEnd"])
+                            l1)
         l2.Run()
+        tend = time.time()
+        print(tend - tstart)
 
         # set output channels from simulation for Export
         vcar = l2.lapTimeSimDict["vcar"]  # car speed [m/s]


### PR DESCRIPTION
default car and track took over 20 seconds to run. It now takes sub 1 second. This will allow for longer/ more detailed track models without taking minutes to run. 
This performance increase was enabled by removing needless running of functions and avoiding continual recalculation of the array for GGVSurfInterp.